### PR TITLE
Remove Bitcoin core info dialog & unneeded variables

### DIFF
--- a/bin/install-core
+++ b/bin/install-core
@@ -181,7 +181,7 @@ ps -p $get_size &>/dev/null && fg %$(jobs -l | grep $get_size | cut -f1 -d' ' | 
 assumed_chain_state_size=$(grep --max-count=1 m_assumed_chain_state_size $destination_dir/chainparams.cpp | sed 's/[^0-9]*//g')
 
 # Display information about pruning and initial block download while user waits for download
-space=$(($(df --output=size $SOURCE | tail -1)/1024 + - ( assumed_chain_state_size + 10 )*1024))
+space=$(($(df --output=size $SOURCE | tail -1) / 1024 - ( assumed_chain_state_size + 10 ) * 1024))
 prune_MiB=$((space > 1907 ? space : 1907 ))
 
 # Bring Bitcoin Core download to foreground to display progress and wait for it to complete
@@ -220,6 +220,7 @@ mkdir --parents $DATA_DIR/{chainstate,wallets,blocks}
 mv --force $LOCAL_DIR/{bitcoin.conf,README.md} $DATA_DIR
 sed --in-place 's/#rpcport=<port>/rpcport=17600/' $DATA_DIR/bitcoin.conf   # set -rpcport for Tails
 sed --in-place "s/#datadir=<dir>/datadir=$DATA_DIR/" $DATA_DIR/bitcoin.conf  # set -datadir for Tails
+sed -i "s/#prune=<n>/prune=$prune_MiB/" $DATA_DIR/bitcoin.conf # set -prune for Tails
 ln --symbolic --force /media/$USER $DATA_DIR/wallets     # links media mount directory to wallets folder for easier loading of watch encrypted or external media wallets
 chmod -w $DATA_DIR/wallets	# TODO see what permissions bitcoin-core would have made its folders at.
 ln --symbolic --force /tmp/debug.log $DATA_DIR/debug.log # links debug.log to tmp so logs won't persist restart

--- a/bin/install-core
+++ b/bin/install-core
@@ -267,7 +267,7 @@ if ((versions < 2)); then
     (
     # Temporarily change $HOME directory make Bail's datadir the default 
     HOME+=/Persistent
-    # Symlink .configand .cache to dotfiles so settings persist
+    # Symlink .config and .cache to dotfiles so changed GUI settings persist
     ln -s $DOTFILES/.{config,cache} $HOME &>/dev/null
     zenity -notification "Use the default data directory."
     bitcoin-qt-wrapper -choosedatadir -prune=$prune_MiB

--- a/bin/install-core
+++ b/bin/install-core
@@ -222,7 +222,7 @@ sed --in-place 's/#rpcport=<port>/rpcport=17600/' $DATA_DIR/bitcoin.conf   # set
 sed --in-place "s/#datadir=<dir>/datadir=$DATA_DIR/" $DATA_DIR/bitcoin.conf  # set -datadir for Tails
 sed -i "s/#prune=<n>/prune=$prune_MiB/" $DATA_DIR/bitcoin.conf # set -prune for Tails
 ln --symbolic --force /media/$USER $DATA_DIR/wallets     # links media mount directory to wallets folder for easier loading of watch encrypted or external media wallets
-chmod -w $DATA_DIR/wallets	# TODO see what permissions bitcoin-core would have made its folders at.
+chmod -w $DATA_DIR/wallets
 ln --symbolic --force /tmp/debug.log $DATA_DIR/debug.log # links debug.log to tmp so logs won't persist restart
 ln --symbolic $DATA_DIR $HOME &>/dev/null # This can't be persisted by dotfiles so an autostart remakes it.
 

--- a/bin/install-core
+++ b/bin/install-core
@@ -179,13 +179,10 @@ fi
 # Bring chainparams.cpp download to foreground then set assumed chainstate & blockchain size
 ps -p $get_size &>/dev/null && fg %$(jobs -l | grep $get_size | cut -f1 -d' ' | tr -c -d '[:digit:]')
 assumed_chain_state_size=$(grep --max-count=1 m_assumed_chain_state_size $destination_dir/chainparams.cpp | sed 's/[^0-9]*//g')
-assumed_blockchain_size=$(grep --max-count=1 m_assumed_blockchain_size $destination_dir/chainparams.cpp | sed 's/[^0-9]*//g')
 
 # Display information about pruning and initial block download while user waits for download
-space=$(($(df --output=size $SOURCE | tail -1)/1024 - ( assumed_chain_state_size+10 )*1024))
+space=$(($(df --output=size $SOURCE | tail -1)/1024 + - ( assumed_chain_state_size + 10 )*1024))
 prune_MiB=$((space > 1907 ? space : 1907 ))
-prune_GB=$(( (prune_MiB+1)*2**20/10**9))
-backup_days=$((prune_MiB/309))
 
 # Bring Bitcoin Core download to foreground to display progress and wait for it to complete
 printf '\033]2;Downloading Bitcoin Core...\a'
@@ -266,7 +263,6 @@ if ((versions < 2)); then
     # TODO Make it easier to read. and dont run on reinstalls!
     sleep 5 # wait so the dialogs open on top of bitcoin core.
     zenity --info --title='Setup almost complete' --icon-name=bails128 "$ICON" --width=552 --text='Bitcoin Core will begin syncing the block chain automatically.\nMake sure no one messes with the PC.\n\nTo lock the screen for privacy, press ❖+L (⊞+L or ⌘+L)\n\nIt is safer to exit Bitcoin Core (Ctrl+Q), <a href="file:///usr/share/doc/tails/website/doc/first_steps/shutdown.en.html">shutdown Tails</a> and take your Bails USB stick with you or store it in a safe place than leave Tails running unattended where people you distrust could tamper with it.\n\nIf you want to learn more about using Tails safely read the <a href="file:///usr/share/doc/tails/website/doc.en.html">documentation</a>.\n\nAnother excellent read to improve your physical and digital security tactics is the <a href="http://lxjacvxrozjlxd7pqced7dyefnbityrwqjosuuaqponlg3v7esifrzad.onion/en/">security in-a-box</a> website.'
-    zenity --info --title='Bitcoin Core info' --icon-name=bitcoin128 "$ICON" --width=552 --text="<b>Setup</b>\n---------------------\nBitcoin Core is the original Bitcoin client and it builds the backbone of the network. It will download and process the entire history of Bitcoin transactions, currently $assumed_blockchain_size gigabytes.\n\nDepending on your computer and network speed, the synchronization process can take anywhere from a few hours to a day or more.\n\nThis initial synchronization is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run Bitcoin Core, it will continue downloading where it left off.\n\nLimiting block chain storage to $prune_GB GB (<b>sufficient to restore backups $backup_days days old</b>)"
 fi &>/dev/null &
 
 # Exit by killing controlling terminal

--- a/bin/install-core
+++ b/bin/install-core
@@ -254,7 +254,7 @@ fi
 
 printf '\033]2;Bitcoin Core installation complete!\a'
 
-bitcoin-qt-wrapper &
+bitcoin-qt-wrapper -choosedatadir -prune=$prune_MiB &
 
 # Clear notifications
 dbus-send --session --type=method_call --dest=org.gnome.Shell /org/gnome/Shell org.gnome.Shell.Eval string:'Main.panel.statusArea.dateMenu._messageList._sectionList.get_children().forEach(s => s.clear());'


### PR DESCRIPTION
It is better to just use the one provided by Bitcoin Core on first launch.