### PR TITLE
Use zenity for Welcome to Bitcoin dialog

### DIFF
--- a/b
+++ b/b
@@ -62,10 +62,12 @@ else
     rm -rvf "$BAILS_DIR"
     link-dotfiles
   ) & # Run persistent setup in background
-  # shellcheck disable=SC1091
-  [ -z "$1" ] && . install-core # Don't update core if ran with a parameter
-  wait
-  if [ -z "$1" ]; then
+  if [ -z "$1" ]; then # Install/Update core if ran without a parameter
+    # shellcheck disable=SC1091
+    . install-core && bails-wallet
+    wait
+    # Display info about IBD, keeping Tails private and extra reading material
+    zenity --info --title='Setup almost complete' --icon-name=bails128 "$ICON" --text='Bitcoin Core has begun syncing the block chain automatically.\nMake sure no one messes with the PC.\n\nTo lock the screen for privacy, press ❖+L (⊞+L or ⌘+L)\n\nIt is safer to exit Bitcoin Core (Ctrl+Q), <a href="file:///usr/share/doc/tails/website/doc/first_steps/shutdown.en.html">shutdown Tails</a> and take your Bails USB stick with you or store it in a safe place than leave Tails running unattended where people you distrust could tamper with it.\n\nIf you want to learn more about using Tails safely read the <a href="file:///usr/share/doc/tails/website/doc.en.html">documentation</a>.\n\nAnother excellent read to improve your physical and digital security tactics is the <a href="'"$SECURITY_IN_A_BOX_TOR_URL"'">security in-a-box</a> website.'
     zenity --info --title="Bails install successful" --text="Bails $VERSION has been installed." "$ICON" --icon-name=bails128
     # Exit by killing controlling terminal
     echo "Bails installation complete! 

--- a/b
+++ b/b
@@ -24,10 +24,11 @@
 # Sets environment variable and launches install-core and/or installs Bails
 ###############################################################################
 
-export VERSION='v0.7.0-alpha'
+export VERSION='v0.7.2-alpha'
 export WAYLAND_DISPLAY="" # Needed for zenity dialogs to have window icon
 export ICON="--window-icon=$HOME/.local/share/icons/bails128.png"
 export DOTFILES='/live/persistence/TailsData_unlocked/dotfiles'
+readonly SECURITY_IN_A_BOX_TOR_URL="http://lxjacvxrozjlxd7pqced7dyefnbityrwqjosuuaqponlg3v7esifrzad.onion/en/"
 BAILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ "$1" == "--version" ]; then

--- a/b
+++ b/b
@@ -44,6 +44,7 @@ elif [[ $(id -u) = "0" ]]; then # Check for root.
   "
     read -rp "PRESS ENTER TO EXIT SCRIPT, AND RUN AGAIN AS $USER. "
 else
+  printf '\033]2;Welcome to Bails!\a'
   # Install Bails to tmpfs
   rsync -rvh "$BAILS_DIR/bails/" "$HOME"
   # shellcheck disable=SC1091

--- a/bails/.config/Bitcoin/Bitcoin-Qt.conf
+++ b/bails/.config/Bitcoin/Bitcoin-Qt.conf
@@ -1,3 +1,4 @@
 [General]
 mask_values=true
 strThirdPartyTxUrls=explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/tx/%s
+strDataDir=/live/persistence/TailsData_unlocked/Persistent/.bitcoin

--- a/bails/.local/bin/bails-menu
+++ b/bails/.local/bin/bails-menu
@@ -29,8 +29,8 @@
 # Set environment variables
 export WAYLAND_DISPLAY=""
 export DOTFILES="/live/persistence/TailsData_unlocked/dotfiles"
-export LOCAL_DIR="$DOTFILES/.local/"
 export DATA_DIR="/live/persistence/TailsData_unlocked/Persistent/.bitcoin"
+XDG_DATA_HOME="$DOTFILES/.local/share"
 
 
 onlynet_onion() {
@@ -57,7 +57,7 @@ Bitcoin Core will continue to connect to both clearnet and Tor (onion) peers.' -
 }
 
 # Display menu and get user response
-response=$(zenity --question --window-icon="$LOCAL_DIR/share/icons/bails128.png" \
+response=$(zenity --question --window-icon="$XDG_DATA_HOME/icons/bails128.png" \
     --icon-name="bails128" --title="Bails menu" \
     --text="Wallet - Create a new seed backup or recover an existing seed.
 
@@ -75,7 +75,7 @@ case "$response" in
 "Wallet") bails-wallet ;;
 "Clone") bails-clone ;;
 "Backup") bails-backup ;;
-"Settings") response2=$(zenity --window-icon="$LOCAL_DIR/share/icons/bails128.png" --question \
+"Settings") response2=$(zenity --window-icon="$XDG_DATA_HOME/icons/bails128.png" --question \
         --icon-name=org.gnome.Settings --title=Settings --text="Configure Bitcoin Core on Tails\n\nWarning: Only install or update software retaining a good reputation." \
         --extra-button="Update Bitcoin Core" --extra-button="Update Bails" --extra-button="$action Sparrow" --extra-button="Network Privacy" \
         --switch) ;;
@@ -89,14 +89,14 @@ esac
 case "$response2" in
     "Donate") xdg-open bitcoin: ;; # FIXME: change address
     "Report a Bug") tor-browser https://github.com/BenWestgate/Bails/issues ;;
-    "About") zenity --info --window-icon="$LOCAL_DIR/share/icons/bails128.png" \
-        --title="About Bails" --icon-name=bails128 --text="$($LOCAL_DIR/share/bails/b --version)\n\nCopyright © 2024 Ben Westgate\n\nPlease contribute if you find Bails useful. Visit <a href='https://twitter.com/BenWestgate_'>https://twitter.com/BenWestgate_</a> for further information about the software.\nThe source code is available from <a href='https://github.com/BenWestgate/Bails'>https://github.com/BenWestgate/Bails</a>.\n\nThis is experimental software.\nDistributed under the MIT software license, see the accompanying file COPYING or <a href='https://opensource.org/licenses/MIT'>https://opensource.org/licenses/MIT</a>"; bails-menu ;;
+    "About") zenity --info --window-icon="$XDG_DATA_HOME/icons/bails128.png" \
+        --title="About Bails" --icon-name=bails128 --text="$($XDG_DATA_HOME/bails/b --version)\n\nCopyright © 2024 Ben Westgate\n\nPlease contribute if you find Bails useful. Visit <a href='https://twitter.com/BenWestgate_'>https://twitter.com/BenWestgate_</a> for further information about the software.\nThe source code is available from <a href='https://github.com/BenWestgate/Bails'>https://github.com/BenWestgate/Bails</a>.\n\nThis is experimental software.\nDistributed under the MIT software license, see the accompanying file COPYING or <a href='https://opensource.org/licenses/MIT'>https://opensource.org/licenses/MIT</a>"; bails-menu ;;
     "Online Help") xdg-open https://bitcoin-core-on-tails.slack.com/ && \
         xdg-open https://t.me/bails_support ;;
     "Update Bitcoin Core") gnome-terminal --title="Updating Bitcoin Core..." --hide-menubar \
         -- "install-core" ;;
     "Update Bails") gnome-terminal --title="Updating Bails..." --hide-menubar \
-        -- "git clone https://github.com/benwestgate/bails --depth=1 && bails/b --update" ;;
+        -- /bin/bash -c "git clone https://github.com/benwestgate/bails --depth=1 && bails/b --update" ;;
     "$action Sparrow") gnome-terminal --title="$action Sparrow Wallet" --hide-menubar \
         -- "install-sparrow" ;;
     "Network Privacy") onlynet_onion; bails-menu ;;

--- a/bails/.local/bin/install-core
+++ b/bails/.local/bin/install-core
@@ -40,8 +40,8 @@ export LOCAL_DIR="$DOTFILES/.local"
 export XDG_STATE_HOME="$LOCAL_DIR/state"
 readonly XDG_DATA_HOME="$LOCAL_DIR/share"
 readonly BITCOIN_CORE_DOMAIN="https://bitcoincore.org"
-readonly SECURITY_IN_A_BOX_TOR_URL="http://lxjacvxrozjlxd7pqced7dyefnbityrwqjosuuaqponlg3v7esifrzad.onion/en/"
 readonly BITCOIN_CHAINPARAMS_URL="https://raw.githubusercontent.com/bitcoin/bitcoin/master/src/kernel/chainparams.cpp"
+readonly GUIX_SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs"
 
 
 # Look for good signatures
@@ -97,7 +97,7 @@ get_guix_sigs() (
     if cd guix.sigs 2>/dev/null; then
         git pull -v # Update guix.sigs
     else
-        git clone https://github.com/bitcoin-core/guix.sigs --depth=1
+        git clone $GUIX_SIGS_REPO_URL --depth=1
     fi 
 )
 
@@ -122,9 +122,6 @@ set -m # Enable job control to bring background downloads to the foreground
 # Download to Persistent Storage if setup, otherwise amnesia
 cd "$XDG_DATA_HOME/bitcoin" || cd "$HOME/.local/share/bitcoin" || exit 1
 DOWNLOAD_DIR=$PWD
-
-# Download chain parameters in background
-retry_on_fail wget --continue -O chainparams.cpp $BITCOIN_CHAINPARAMS_URL & get_size=$!
 retry_on_fail wget "$BITCOIN_CORE_DOMAIN/en/download" # Query latest version
 VER=$(grep -oPm1 '(?<=bitcoin-core-).*(?=/SHA256SUMS.asc)' download)
 # Download Bitcoin core checksums and signatures in background
@@ -149,6 +146,8 @@ else # Import a trusted set on first-run.
             echo "Warning: Bails trusted key ${key/'./trusted-keys/'} did not sign Bitcoin Core version $VER, skipping."
         fi
     done
+    # Download chain parameters in background to set prune
+    retry_on_fail wget --continue -O chainparams.cpp $BITCOIN_CHAINPARAMS_URL & get_size=$!
 fi
 
 printf '\033]2;Setup Persistent Storage...\a'
@@ -189,13 +188,12 @@ ps -p $get_core &>/dev/null && fg %"$(jobs -l | grep $get_core | cut -f1 -d' ' |
 # Verify download integrity
 if file_name=$(sha256sum --ignore-missing --check SHA256SUMS); then
     zenity --notification --text="Bitcoin Core download integrity successfully verified." --window-icon=checkbox-checked
+    stop-btc # Kill Bitcoin Core if running, wait for it to shutdown safely
 else
     zenity --error --title="Download integrity failure" --text="Checksum does not match what was expected.\n\nClick OK to try downloading Bitcoin Core again." --ellipsize "$ICON" && \
     install-core	# Launch this script again
     exit 1
 fi
-
-stop-btc # Kill Bitcoin Core if running, wait for it to shutdown safely
 printf '\033]2;Installing Bitcoin Core...\a'
 tar -xvf "${file_name::-4}" --strip-components=1 --directory=$LOCAL_DIR
 # Move completed verified download to persistent storage
@@ -210,36 +208,33 @@ sed -i 's/#rpcport=<port>/rpcport=17600/' "$DOTFILES/.bitcoin/bitcoin.conf"     
 sed -i "s,#datadir=<dir>,datadir=$DATA_DIR," "$DOTFILES/.bitcoin/bitcoin.conf"  # set -datadir for Tails
 sed -i "s,#debuglogfile=<file>,debuglogfile=$HOME/.bitcoin/debug.log," "$DOTFILES/.bitcoin/bitcoin.conf" # set log to tmpfs
 link-dotfiles
-[ -e $DATA_DIR/wallets ] || mkdir -p $DATA_DIR/{wallets,blocks} # TODO: this can be replaced by creating the symlink in panic mode solution
-ln --symbolic --force -b /media/"$USER" $DATA_DIR/wallets     # links media mount directory to wallets folder for easier loading of watch encrypted or external media wallets
-chmod -w $DATA_DIR/wallets  # TODO: this can be deleted when panic mode is added
-ln --symbolic --force -b {"$HOME"/.bitcoin,$DATA_DIR}/debug.log # symlinks to tmpfs debug.log
-ln --symbolic --force -b $DOTFILES/.bitcoin/{README.md,bitcoin.conf} $DATA_DIR # symlinks to dotfiles/.bitcoin
-# Bring chainparams.cpp download to foreground, set assumed chainstate & blockchain size, configure prune
-ps -p $get_size &>/dev/null && fg %"$(jobs -l | grep $get_size | cut -f1 -d' ' | tr -c -d '[:digit:]')"
-assumed_chain_state_size=$(grep --max-count=1 m_assumed_chain_state_size "$DOWNLOAD_DIR"/chainparams.cpp | sed 's/[^0-9]*//g')
-assumed_blockchain_size=$(grep --max-count=1 m_assumed_blockchain_size "$DOWNLOAD_DIR"/chainparams.cpp | sed 's/[^0-9]*//g')
-# Calculate space available for block file storage
-space=$(($(df --output=avail $SOURCE | tail -1) * 1024 / 10 ** 9 - assumed_chain_state_size - 10))
-prune_GB=$((space > 2 ? space : 2 ))
-# Disable pruning if USB stick is large enough
-prune_MiB=$((space > assumed_blockchain_size ? 0 : prune_GB * 10 ** 9 / 1024 ** 2))
-# Enable proxies for Tor and prune
-[ -f $DATA_DIR/settings.json ] || echo '{
-    "dbcache": "450",
-    "onion": "127.0.0.1:9050",
-    "proxy": "127.0.0.1:9050",
-    "prune": "'$prune_MiB'",
-    "server": true
-}' > $DATA_DIR/settings.json
-# Update $PATH environment variable to include new user bin
-# shellcheck source=/dev/null
-. "$HOME"/.profile
 printf "\033]2;Bitcoin Core %s complete!\a" $action
 
-if [ -e $XDG_STATE_HOME/installed ]; then
+if [ -e $XDG_STATE_HOME/installed ] && [ -n "$OLD_VER" ]; then
     zenity --info --title='Update successful' --text="${OLD_VER%Copyright*}was updated to $(bitcoind --version | head -1 | cut -d' ' -f4)" "$ICON" --icon-name=bitcoin128 &
 else
+    mkdir -p $DATA_DIR/{wallets,blocks} # TODO: this can be replaced by creating the symlink in panic mode solution
+    ln --symbolic --force -b /media/"$USER" $DATA_DIR/wallets     # links media mount directory to wallets folder for easier loading of watch encrypted or external media wallets
+    chmod -w $DATA_DIR/wallets  # TODO: this can be deleted when panic mode is added
+    ln --symbolic --force -b {"$HOME"/.bitcoin,$DATA_DIR}/debug.log # symlinks to tmpfs debug.log
+    ln --symbolic --force -b $DOTFILES/.bitcoin/{README.md,bitcoin.conf} $DATA_DIR # symlinks to dotfiles/.bitcoin
+    # Bring chainparams.cpp download to foreground, set assumed chainstate & blockchain size, configure prune
+    ps -p $get_size &>/dev/null && fg %"$(jobs -l | grep $get_size | cut -f1 -d' ' | tr -c -d '[:digit:]')"
+    assumed_chain_state_size=$(grep --max-count=1 m_assumed_chain_state_size "$DOWNLOAD_DIR"/chainparams.cpp | sed 's/[^0-9]*//g')
+    assumed_blockchain_size=$(grep --max-count=1 m_assumed_blockchain_size "$DOWNLOAD_DIR"/chainparams.cpp | sed 's/[^0-9]*//g')
+    # Calculate space available for block file storage
+    space=$(($(df --output=avail $SOURCE | tail -1) * 1024 / 10 ** 9 - assumed_chain_state_size - 10))
+    prune_GB=$((space > 2 ? space : 2 ))
+    # Disable pruning if USB stick is large enough
+    prune_MiB=$((space > assumed_blockchain_size ? 0 : prune_GB * 10 ** 9 / 1024 ** 2))
+    echo '{
+        "dbcache": "450",
+        "onion": "127.0.0.1:9050",
+        "proxy": "127.0.0.1:9050",
+        "prune": "'$prune_MiB'",
+        "server": true
+    }' > $DATA_DIR/settings.json # Enable server, proxies for Tor and prune
+    
     if ((prune_MiB)); then
         storageRequiresMsg="Approximately $((prune_GB + assumed_chain_state_size)) GB of data will be stored in your Persistent Storage."
         expected_backup_days=$((prune_GB * 10**9 / (2250000 * 86400 / 600)))
@@ -251,6 +246,9 @@ else
 Bitcoin Core will download and store a copy of the Bitcoin block chain. $storageRequiresMsg\n
 Bitcoin Core has begun to download and process the full Bitcoin block chain ($assumed_blockchain_size GB) starting with the earliest transactions in 2009 when Bitcoin initially launched.\n
 This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run Bitcoin Core, it will continue downloading where it left off.$prune_explanation" "$ICON" &
+    # Update $PATH environment variable to include new user bin
+    # shellcheck source=/dev/null
+    . "$HOME"/.profile
     export DONT_ASK_DONATIONS=1 # Don't ask for donations on first install
 fi
 wrapped bitcoin-qt -min -startupnotify=link-dotfiles

--- a/bails/.local/bin/install-core
+++ b/bails/.local/bin/install-core
@@ -238,28 +238,21 @@ prune_MiB=$((space > assumed_blockchain_size ? 0 : prune_GB * 10 ** 9 / 1024 ** 
 printf "\033]2;Bitcoin Core %s complete!\a" $action
 
 if [ -e $XDG_STATE_HOME/installed ]; then
-    gtk-launch bitcoin-qt
-    zenity --info --title='Update successful' --text="${OLD_VER%Copyright*}was updated to $(bitcoind --version | head -1 | cut -d' ' -f4)" "$ICON" --icon-name=bitcoin128
+    zenity --info --title='Update successful' --text="${OLD_VER%Copyright*}was updated to $(bitcoind --version | head -1 | cut -d' ' -f4)" "$ICON" --icon-name=bitcoin128 &
 else
-    (
     if ((prune_MiB)); then
-        prune_text=" and storage limit"
-        prune_text2=" and <i>$prune_GB GB</i>"
+        storageRequiresMsg="Approximately $((prune_GB + assumed_chain_state_size)) GB of data will be stored in your Persistent Storage."
+        expected_backup_days=$((prune_GB * 10**9 / (2250000 * 86400 / 600)))
+        prune_explanation="\n\nBails has chosen to limit block chain storage (pruning) to $prune_GB GB (sufficient to restore backups $expected_backup_days days old), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low."
+    else
+        storageRequiresMsg="At least $((assumed_blockchain_size + assumed_chain_state_size)) GB of data will be stored in your Persistent Storage, and it will grow over time."
     fi
+    zenity --info --title Welcome --icon-name=bitcoin128 --text="<i>Welcome to Bitcoin Core.</i>\n\n
+Bitcoin Core will download and store a copy of the Bitcoin block chain. $storageRequiresMsg\n
+Bitcoin Core has begun to download and process the full Bitcoin block chain ($assumed_blockchain_size GB) starting with the earliest transactions in 2009 when Bitcoin initially launched.\n
+This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run Bitcoin Core, it will continue downloading where it left off.$prune_explanation" "$ICON" &
     export DONT_ASK_DONATIONS=1 # Don't ask for donations on first install
-    # Temporarily change $HOME directory make Bails's datadir the default
-    HOME=~/Persistent
-    until [ -f $DATA_DIR/bitcoind.pid ]; do
-        zenity --notification --text="Use the default data directory$prune_text.\n<i>$HOME/.bitcoin</i>$prune_text2" --window-icon=bails128
-        pgrep bitcoin || wrapped bitcoin-qt -choosedatadir -prune=$prune_MiB -min
-        bitcoin-cli --rpcwait createwallet test_permissions && stop-btc
-        # grep /strDataDir= $XDG_CONFIG_HOME/Bitcoin/Bitcoin-Qt.conf && stop-btc
-        sed -i '/strDataDir=/d' $XDG_CONFIG_HOME/Bitcoin/Bitcoin-Qt.conf
-    done
-    )
-    link-dotfiles
-    (( $(find $DATA_DIR/wallets/* | wc -l) < 2 )) && bails-wallet
-    # Display info about IBD, keeping Tails private and extra reading material
-    zenity --info --title='Setup almost complete' --icon-name=bails128 "$ICON" --text='Bitcoin Core has begun syncing the block chain automatically.\nMake sure no one messes with the PC.\n\nTo lock the screen for privacy, press ❖+L (⊞+L or ⌘+L)\n\nIt is safer to exit Bitcoin Core (Ctrl+Q), <a href="file:///usr/share/doc/tails/website/doc/first_steps/shutdown.en.html">shutdown Tails</a> and take your Bails USB stick with you or store it in a safe place than leave Tails running unattended where people you distrust could tamper with it.\n\nIf you want to learn more about using Tails safely read the <a href="file:///usr/share/doc/tails/website/doc.en.html">documentation</a>.\n\nAnother excellent read to improve your physical and digital security tactics is the <a href="'"$SECURITY_IN_A_BOX_TOR_URL"'">security in-a-box</a> website.'
 fi
+wrapped bitcoin-qt -min -startupnotify=link-dotfiles
+wait
 touch $XDG_STATE_HOME/installed

--- a/bails/.local/bin/install-core
+++ b/bails/.local/bin/install-core
@@ -196,10 +196,8 @@ else
 fi
 printf '\033]2;Installing Bitcoin Core...\a'
 tar -xvf "${file_name::-4}" --strip-components=1 --directory=$LOCAL_DIR
-# Move completed verified download to persistent storage
 rm -Rvf "$DOWNLOAD_DIR"/{download*,*.tmp,wget-log*}
 until [ -f $XDG_DATA_HOME/bails/b ]; do sleep 1; done # Be sure Bails installed
-rsync -vh --remove-source-files --recursive "$DOWNLOAD_DIR" $XDG_DATA_HOME
 # Change mime association from electrum to bitcoin core
 sed 's/bitcoin=electrum/bitcoin=bitcoin-qt/g' /usr/share/applications/mimeinfo.cache > "$XDG_DATA_HOME/applications/mimeinfo.cache"
 # Configure data directory
@@ -213,6 +211,8 @@ printf "\033]2;Bitcoin Core %s complete!\a" $action
 if [ -e $XDG_STATE_HOME/installed ] && [ -n "$OLD_VER" ]; then
     zenity --info --title='Update successful' --text="${OLD_VER%Copyright*}was updated to $(bitcoind --version | head -1 | cut -d' ' -f4)" "$ICON" --icon-name=bitcoin128 &
 else
+    # Move completed verified download to persistent storage
+    rsync -vh --remove-source-files --recursive "$DOWNLOAD_DIR" $XDG_DATA_HOME
     mkdir -p $DATA_DIR/{wallets,blocks} # TODO: this can be replaced by creating the symlink in panic mode solution
     ln --symbolic --force -b /media/"$USER" $DATA_DIR/wallets     # links media mount directory to wallets folder for easier loading of watch encrypted or external media wallets
     chmod -w $DATA_DIR/wallets  # TODO: this can be deleted when panic mode is added

--- a/bails/.local/bin/install-core
+++ b/bails/.local/bin/install-core
@@ -28,7 +28,6 @@
 
 # Set environment variables and constants
 export PATH="$HOME/.local/bin:$PATH"
-export DOWNLOAD_DIR="$HOME/.local/share/bitcoin"
 export ICON=--window-icon="$HOME/.local/share/icons/bails128.png"
 export WAYLAND_DISPLAY="" # Needed for zenity dialogs to have window icon
 export TMPDIR=$XDG_RUNTIME_DIR
@@ -116,11 +115,14 @@ retry_on_fail() {
 # Begin execution here
 ###############################################################################
 
-printf '\033]2;Welcome to Bails!\a'
+printf '\033]2;Checking for latest Bitcoin Core version\a'
 pkill tca &>/dev/null # Close tor connection assistant to clean up the screen
 set -m # Enable job control to bring background downloads to the foreground
 
-cd "$DOWNLOAD_DIR" || exit 1
+# Download to Persistent Storage if setup, otherwise amnesia
+cd "$XDG_DATA_HOME/bitcoin" || cd "$HOME/.local/share/bitcoin" || exit 1
+DOWNLOAD_DIR=$PWD
+
 # Download chain parameters in background
 retry_on_fail wget --continue -O chainparams.cpp $BITCOIN_CHAINPARAMS_URL & get_size=$!
 retry_on_fail wget "$BITCOIN_CORE_DOMAIN/en/download" # Query latest version
@@ -237,7 +239,7 @@ printf "\033]2;Bitcoin Core %s complete!\a" $action
 
 if [ -e $XDG_STATE_HOME/installed ]; then
     gtk-launch bitcoin-qt
-    zenity --info --title='Update successful' --text="${OLD_VER%Copyright}was updated to $(bitcoind --version)" "$ICON" --icon-name=bitcoin128
+    zenity --info --title='Update successful' --text="${OLD_VER%Copyright*}was updated to $(bitcoind --version | head -1 | cut -d' ' -f4)" "$ICON" --icon-name=bitcoin128
 else
     (
     if ((prune_MiB)); then

--- a/bails/.local/bin/persistent-setup
+++ b/bails/.local/bin/persistent-setup
@@ -35,7 +35,6 @@ passwd_unset=$(passwd -S "$USER" | grep -c NP)
 [ -f $SET_UP ] || zenity --title='Welcome to Bails' --info \
     --text="Thank you for choosing Bails, a self-custodial Bitcoin wallet and full node.\n\nDuring this initial setup process, we will guide you through the necessary steps\nto ensure a smooth experience. Let's get started!" \
     --no-wrap --ok-label='Continue' "$ICON" --icon-name=bails128
-printf '\033]2;Setup the Persistent Storage\a'
 
 # Check for already unlocked Persistent Storage
 pgrep -f spaced-repetition || if /usr/local/lib/tpscli is-unlocked; then
@@ -70,6 +69,7 @@ else:
         printf '%s\n%s' "$existing_passphrase" "$existing_passphrase" | passwd || echo "FAILURE to change passphrase"
     fi
 else
+    printf '\033]2;Setup the Persistent Storage\a'
     # Choose passphrase
     zenity --warning --title='Choose a strong passphrase' --no-wrap "$ICON" \
         --text='It is important to select a strong passphrase to protect your Bitcoin data.\n

--- a/bails/.local/bin/persistent-setup
+++ b/bails/.local/bin/persistent-setup
@@ -66,7 +66,7 @@ else:
     done
     unset entropy
     [ -f $SET_UP ] || if ((passwd_unset)); then
-        # Change user account password to Persistent Storage passphrase for spaced repetition practice.a
+        # Change user account password to Persistent Storage passphrase for spaced repetition practice.
         printf '%s\n%s' "$existing_passphrase" "$existing_passphrase" | passwd || echo "FAILURE to change passphrase"
     fi
 else


### PR DESCRIPTION
This simplifies the code and lets Bitcoin-Qt start minimized and syncs while waiting for the user to read the dialog. It also prevents people from changing the datadir or prune settings.

Some bugs related to updating Bails and Bitcoin Core were fixed.

git pull doesn't work into a symlink folder so updates must download to the dotfiles directly. This made an ugly can't remove source file error from rsync so it was moved to only copy for new installations (where the downloads and clone happened to the tmpfs first.

Also moved "Setup the Persistent Storage" dialog title to only when it is actually setup, not anytime persistent-setup runs (to check the needed features are on, or capture an existing Persistent Storage's passphrase).

strDataDir= key was added back to Bitcoin-Qt.conf since we don't need it empty for the Welcome Screen anymore. This gives some extra protection against not using the correct data dir if launched from terminal and ~/.bitcoin was deleted.

Chain params are no longer downloaded for updates (only used to set initial prune value).

Set a variable for the guix_sigs_repo.

Moved other commands that threw error messages on updates behind the conditional so they don't run during updates.

Bumps version to 0.7.2-alpha