### PR TITLE
fix wrong icon path which was crashing Gtk dialogs

### DIFF
--- a/bails/.local/lib/python3.11/site-packages/bails-wallet/codex32_confirm.py
+++ b/bails/.local/lib/python3.11/site-packages/bails-wallet/codex32_confirm.py
@@ -42,7 +42,7 @@ class EntryWindow(Gtk.Window):
         # Set a monospace font
         font_desc = Pango.FontDescription("Monospace 17")
 
-        self.set_icon_from_file(xdg_data_home() + "/icons/bails128.png")
+        self.set_icon_from_file(str(xdg_data_home()) + "/icons/bails128.png")
 
         for i in range(self.words):
             entry = Gtk.Entry()

--- a/bails/.local/lib/python3.11/site-packages/bails/passphrase.py
+++ b/bails/.local/lib/python3.11/site-packages/bails/passphrase.py
@@ -34,7 +34,7 @@ class PassphraseDialog(Gtk.Dialog):
     def __init__(self, parent, title):
         Gtk.Dialog.__init__(self, title, parent, 0,
                             (Gtk.STOCK_OK, Gtk.ResponseType.OK, Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL))
-        self.set_icon_from_file(xdg_data_home() + "/icons/bails128.png")
+        self.set_icon_from_file(str(xdg_data_home()) + "/icons/bails128.png")
 
         self.set_default_size(500, 80)
 

--- a/bails/.local/lib/python3.11/site-packages/bails/set_pass.py
+++ b/bails/.local/lib/python3.11/site-packages/bails/set_pass.py
@@ -42,7 +42,7 @@ class PassphraseDialog(Gtk.Dialog):
                             (
                             Gtk.STOCK_OK, Gtk.ResponseType.OK, Gtk.STOCK_CANCEL,
                             Gtk.ResponseType.CANCEL))
-        self.set_icon_from_file(xdg_data_home() + "/icons/bails128.png")
+        self.set_icon_from_file(str(xdg_data_home()) + "/icons/bails128.png")
         self.set_default_size(400, 200)
 
         box = self.get_content_area()
@@ -165,8 +165,8 @@ class SimplePassphraseDialog(Gtk.Dialog):
                             (Gtk.STOCK_OK, Gtk.ResponseType.OK))
 
         # Set the icon from a file path
-        icon_path = "/home/amnesia/.local/share/icons/bails128.png"
-        self.set_icon_from_file(icon_path)
+        self.set_icon_from_file(str(xdg_data_home()) + "/icons/bails128.png")
+
 
         self.set_default_size(500, 150)
 


### PR DESCRIPTION
complex passphrase dialogs and the Gtk string confirmation dialogs were crashing due to this error.